### PR TITLE
Use print() function on both Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ script: mvn clean verify
 
 matrix:
   include:
-    - language: java
-      script: mvn clean verify
     - language: python
       install: pip install flake8
       script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: java
-script: mvn clean verify
-
 matrix:
   include:
+    - language: java
+      script: mvn clean verify
     - language: python
       install: pip install flake8
       script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
-sudo: false
 script: mvn clean verify
+
+matrix:
+  include:
+    - language: java
+      script: mvn clean verify
+    - language: python
+      install: pip install flake8
+      script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics

--- a/target/liberty/wlp/clients/jython/restConnector.py
+++ b/target/liberty/wlp/clients/jython/restConnector.py
@@ -3,6 +3,8 @@
 # wise divested of its trade secrets, irrespective of what has
 # been deposited with the U.S. Copyright Office.
 
+from __future__ import print_function
+
 from java.lang import String
 from java.lang import System
 from java.util import HashMap
@@ -59,13 +61,13 @@ class JMXRESTConnector(object):
 			self.connectAdvanced(host, port, args[0])
 
 	def connectAdvanced(self,host,port,map):
-		print "Connecting to the server..."
+		print("Connecting to the server...")
 		System.setProperty("javax.net.ssl.trustStore", self.trustStore)
 		System.setProperty("javax.net.ssl.trustStorePassword", self.trustStorePassword)
 		url = JMXServiceURL("REST", host, port, "/IBMJMXConnectorREST")
 		self.connector = JMXConnectorFactory.newJMXConnector(url, map)
 		self.connector.connect()
-		print "Successfully connected to the server " + '"' + host + ':%i"' % port
+		print("Successfully connected to the server " + '"' + host + ':%i"' % port)
 
 	def connectBasic(self,host,port,user,password):
 		map = HashMap()
@@ -87,4 +89,3 @@ class JMXRESTConnector(object):
 		# This method can be called after the above connect() is executed successfully.
 		self.mbeanConnection = self.connector.getMBeanServerConnection()
 		return self.mbeanConnection
-


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.